### PR TITLE
Adjust imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following code will read a tag from the MFRC522
 
 ```python
 from time import sleep
-import sys
+import RPi.GPIO as GPIO
 from mfrc522 import SimpleMFRC522
 reader = SimpleMFRC522()
 


### PR DESCRIPTION
Avoids NameError: name 'GPIO' is not defined and RuntimeWarning: This channel is already in use, continuing anyway.  Use GPIO.setwarnings(False) to disable warnings.