### PR TITLE
Add a convenience `cleanup` method to reduce boilerplate

### DIFF
--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -88,3 +88,7 @@ class SimpleMFRC522:
       for i in range(0, 5):
           n = n * 256 + uid[i]
       return n
+
+  @staticmethod
+  def cleanup():
+      GPIO.cleanup()


### PR DESCRIPTION
Since the `SimpleMFRC522` module is all about convenience and less code, providing this method would
- eliminate the need to import the [relatively low-level] `RPi.GPIO` library for using just one method
- provide a more object oriented API

of course if the user needs `GPIO`, they can always import it. Just that it wouldn't be forced by us now.