### PR TITLE
Cleanup indentation and whitespaces, and sort imports as per PEP8

### DIFF
--- a/mfrc522/MFRC522.py
+++ b/mfrc522/MFRC522.py
@@ -136,18 +136,18 @@ class MFRC522:
         self.logger.setLevel(level)
 
         gpioMode = GPIO.getmode()
-        
+
         if gpioMode is None:
             GPIO.setmode(pin_mode)
         else:
             pin_mode = gpioMode
-            
+
         if pin_rst == -1:
             if pin_mode == 11:
                 pin_rst = 15
             else:
                 pin_rst = 22
-            
+
         GPIO.setup(pin_rst, GPIO.OUT)
         GPIO.output(pin_rst, 1)
         self.MFRC522_Init()
@@ -312,7 +312,7 @@ class MFRC522:
         buf = []
         buf.append(self.PICC_SElECTTAG)
         buf.append(0x70)
-        
+
         for i in range(5):
             buf.append(serNum[i])
 

--- a/mfrc522/MFRC522.py
+++ b/mfrc522/MFRC522.py
@@ -22,8 +22,6 @@
 #
 import RPi.GPIO as GPIO
 import spidev
-import signal
-import time
 import logging
 
 class MFRC522:

--- a/mfrc522/MFRC522.py
+++ b/mfrc522/MFRC522.py
@@ -19,10 +19,12 @@
 #
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with MFRC522-Python.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+import logging
+
 import RPi.GPIO as GPIO
 import spidev
-import logging
+
 
 class MFRC522:
     MAX_LEN = 16

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -1,11 +1,9 @@
 # Code by Simon Monk https://github.com/simonmonk/
 
 from . import MFRC522
-import RPi.GPIO as GPIO
 
 class SimpleMFRC522:
 
-    READER = None
 
     KEY = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
     BLOCK_ADDRS = [8, 9, 10]

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -5,86 +5,86 @@ import RPi.GPIO as GPIO
 
 class SimpleMFRC522:
 
-  READER = None
+    READER = None
 
-  KEY = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
-  BLOCK_ADDRS = [8, 9, 10]
+    KEY = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
+    BLOCK_ADDRS = [8, 9, 10]
 
-  def __init__(self):
-    self.READER = MFRC522()
+    def __init__(self):
+        self.READER = MFRC522()
 
-  def read(self):
-      id, text = self.read_no_block()
-      while not id:
-          id, text = self.read_no_block()
-      return id, text
+    def read(self):
+        id, text = self.read_no_block()
+        while not id:
+            id, text = self.read_no_block()
+        return id, text
 
-  def read_id(self):
-    id = self.read_id_no_block()
-    while not id:
-      id = self.read_id_no_block()
-    return id
+    def read_id(self):
+        id = self.read_id_no_block()
+        while not id:
+            id = self.read_id_no_block()
+        return id
 
-  def read_id_no_block(self):
-      (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
-      if status != self.READER.MI_OK:
-          return None
-      (status, uid) = self.READER.MFRC522_Anticoll()
-      if status != self.READER.MI_OK:
-          return None
-      return self.uid_to_num(uid)
+    def read_id_no_block(self):
+        (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
+        if status != self.READER.MI_OK:
+            return None
+        (status, uid) = self.READER.MFRC522_Anticoll()
+        if status != self.READER.MI_OK:
+            return None
+        return self.uid_to_num(uid)
 
-  def read_no_block(self):
-    (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
-    if status != self.READER.MI_OK:
-        return None, None
-    (status, uid) = self.READER.MFRC522_Anticoll()
-    if status != self.READER.MI_OK:
-        return None, None
-    id = self.uid_to_num(uid)
-    self.READER.MFRC522_SelectTag(uid)
-    status = self.READER.MFRC522_Auth(self.READER.PICC_AUTHENT1A, 11, self.KEY, uid)
-    data = []
-    text_read = ''
-    if status == self.READER.MI_OK:
-        for block_num in self.BLOCK_ADDRS:
-            block = self.READER.MFRC522_Read(block_num)
-            if block:
-            		data += block
-        if data:
-             text_read = ''.join(chr(i) for i in data)
-    self.READER.MFRC522_StopCrypto1()
-    return id, text_read
+    def read_no_block(self):
+        (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
+        if status != self.READER.MI_OK:
+            return None, None
+        (status, uid) = self.READER.MFRC522_Anticoll()
+        if status != self.READER.MI_OK:
+            return None, None
+        id = self.uid_to_num(uid)
+        self.READER.MFRC522_SelectTag(uid)
+        status = self.READER.MFRC522_Auth(self.READER.PICC_AUTHENT1A, 11, self.KEY, uid)
+        data = []
+        text_read = ''
+        if status == self.READER.MI_OK:
+            for block_num in self.BLOCK_ADDRS:
+                block = self.READER.MFRC522_Read(block_num)
+                if block:
+                    data += block
+            if data:
+                text_read = ''.join(chr(i) for i in data)
+        self.READER.MFRC522_StopCrypto1()
+        return id, text_read
 
-  def write(self, text):
-      id, text_in = self.write_no_block(text)
-      while not id:
-          id, text_in = self.write_no_block(text)
-      return id, text_in
+    def write(self, text):
+        id, text_in = self.write_no_block(text)
+        while not id:
+            id, text_in = self.write_no_block(text)
+        return id, text_in
 
-  def write_no_block(self, text):
-      (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
-      if status != self.READER.MI_OK:
-          return None, None
-      (status, uid) = self.READER.MFRC522_Anticoll()
-      if status != self.READER.MI_OK:
-          return None, None
-      id = self.uid_to_num(uid)
-      self.READER.MFRC522_SelectTag(uid)
-      status = self.READER.MFRC522_Auth(self.READER.PICC_AUTHENT1A, 11, self.KEY, uid)
-      self.READER.MFRC522_Read(11)
-      if status == self.READER.MI_OK:
-          data = bytearray()
-          data.extend(bytearray(text.ljust(len(self.BLOCK_ADDRS) * 16).encode('ascii')))
-          i = 0
-          for block_num in self.BLOCK_ADDRS:
-            self.READER.MFRC522_Write(block_num, data[(i*16):(i+1)*16])
-            i += 1
-      self.READER.MFRC522_StopCrypto1()
-      return id, text[0:(len(self.BLOCK_ADDRS) * 16)]
+    def write_no_block(self, text):
+        (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
+        if status != self.READER.MI_OK:
+            return None, None
+        (status, uid) = self.READER.MFRC522_Anticoll()
+        if status != self.READER.MI_OK:
+            return None, None
+        id = self.uid_to_num(uid)
+        self.READER.MFRC522_SelectTag(uid)
+        status = self.READER.MFRC522_Auth(self.READER.PICC_AUTHENT1A, 11, self.KEY, uid)
+        self.READER.MFRC522_Read(11)
+        if status == self.READER.MI_OK:
+            data = bytearray()
+            data.extend(bytearray(text.ljust(len(self.BLOCK_ADDRS) * 16).encode('ascii')))
+            i = 0
+            for block_num in self.BLOCK_ADDRS:
+                self.READER.MFRC522_Write(block_num, data[(i*16):(i+1)*16])
+                i += 1
+        self.READER.MFRC522_StopCrypto1()
+        return id, text[0:(len(self.BLOCK_ADDRS) * 16)]
 
-  def uid_to_num(self, uid):
-      n = 0
-      for i in range(0, 5):
-          n = n * 256 + uid[i]
-      return n
+    def uid_to_num(self, uid):
+        n = 0
+        for i in range(0, 5):
+            n = n * 256 + uid[i]
+        return n

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -2,17 +2,17 @@
 
 from . import MFRC522
 import RPi.GPIO as GPIO
-  
+
 class SimpleMFRC522:
 
   READER = None
-  
+
   KEY = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
   BLOCK_ADDRS = [8, 9, 10]
-  
+
   def __init__(self):
     self.READER = MFRC522()
-  
+
   def read(self):
       id, text = self.read_no_block()
       while not id:
@@ -33,7 +33,7 @@ class SimpleMFRC522:
       if status != self.READER.MI_OK:
           return None
       return self.uid_to_num(uid)
-  
+
   def read_no_block(self):
     (status, TagType) = self.READER.MFRC522_Request(self.READER.PICC_REQIDL)
     if status != self.READER.MI_OK:
@@ -48,14 +48,14 @@ class SimpleMFRC522:
     text_read = ''
     if status == self.READER.MI_OK:
         for block_num in self.BLOCK_ADDRS:
-            block = self.READER.MFRC522_Read(block_num) 
+            block = self.READER.MFRC522_Read(block_num)
             if block:
             		data += block
         if data:
              text_read = ''.join(chr(i) for i in data)
     self.READER.MFRC522_StopCrypto1()
     return id, text_read
-    
+
   def write(self, text):
       id, text_in = self.write_no_block(text)
       while not id:
@@ -82,7 +82,7 @@ class SimpleMFRC522:
             i += 1
       self.READER.MFRC522_StopCrypto1()
       return id, text[0:(len(self.BLOCK_ADDRS) * 16)]
-      
+
   def uid_to_num(self, uid):
       n = 0
       for i in range(0, 5):

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -1,10 +1,9 @@
 # Code by Simon Monk https://github.com/simonmonk/
 
-from . import MFRC522
+from .MFRC522 import MFRC522
+
 
 class SimpleMFRC522:
-
-
     KEY = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF]
     BLOCK_ADDRS = [8, 9, 10]
 

--- a/mfrc522/__init__.py
+++ b/mfrc522/__init__.py
@@ -1,4 +1,4 @@
 from .MFRC522 import MFRC522
 from .SimpleMFRC522 import SimpleMFRC522
 
-name = "mfrc522"
+__all__ = ["MFRC522", "SimpleMFRC522"]


### PR DESCRIPTION
- The top-level indent in `SimpleMFRC522` module was 2 spaces, while the inner levels were 4. This PR changes every indentation to the standard 4.
- This PR also trims the redundant whitespaces from the codebase.
- This PR corrects various linter errors
- Lastly, this PR sort and group the imports according to PEP8 specifications.